### PR TITLE
Bug Fix - atan2f_neon_hfp, cosf_neon_sfp

### DIFF
--- a/src/math_cosf.c
+++ b/src/math_cosf.c
@@ -36,9 +36,8 @@ float cosf_neon_hfp(float x)
 float cosf_neon_sfp(float x)
 {
 #ifdef __MATH_NEON
-	asm volatile ("vdup.f32 d0, r0 		\n\t");
-	cosf_neon_hfp(x);
-	asm volatile ("vmov.f32 r0, s0 		\n\t");
+	float xx = x + M_PI_2;
+	return sinf_neon_sfp(xx);
 #else
 	return cosf_c(x);
 #endif

--- a/src/math_debug.c
+++ b/src/math_debug.c
@@ -18,13 +18,13 @@ License along with this library; if not, write to the Free
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+#define WIN32
 
 #include "math_neon.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#include <time.h>
 #ifdef WIN32
 #include <time.h>
 #else


### PR DESCRIPTION
* atan2f_neon_hfp
Since the atan2f_neon_hfp function returns -1 instead of 1 in case of the command "vcgt.f32 d3, d0, d2" at (d0> d2), it would be converted to UINT_MAX value when using the command "vcvt.f32.u32 d3, d3".

 So, It needs to be modified by saving vcgt result value as -1 with "vcvt.f32.s32 d3, d3" command and converting it to 1 with "vabs.f32 d3, d3" command.

 When this is done, modified atan2f_neon_hfp function will return the correct value even if (y / x) is greater than 1.0f ...

 For the same reason, the "polynomial" part needs a similar modification for returning the correct value when x is less than 0

[+] In addition, It need to change the position of the function arguments from "(float x, float y)" to "(float y, float x)"

* cosf_neon_sfp
The existing "cosf_neon_sfp" function was not able to receive the parameters and needs to be modified as follows.